### PR TITLE
Added example of configuration used by uevents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# qbs
+build_release
+default
+products

--- a/info.json
+++ b/info.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.1.0",
+  "name": "uevents",
+  "type": "core-config"
+}

--- a/install
+++ b/install
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# current dir
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# showing help
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "$(basename "$0") [-h] -- Runs the installation:
+    -h/--help       show this help text
+    --production    installs as production release (under UPIPE_ROOT). Otherwise, if not supplied installs under UPIPE_DEV_ROOT (default)
+    --update-alpha  update alpha release symlink to point to the version provided by info.json
+    --update-beta   update beta release symlink to point to the version provided by info.json
+    --update-stable update stable release symlink to point to the version provided by info.json
+    --update-all    update all release symlinks (alpha, beta and stable) to point to the version provided by info.json"
+  exit 0
+fi
+
+updateReleaseSymlinks() {
+  installRoot="$1"
+  declare info=($(cat "$dir/info.json" | jq -r ".name, .version"))
+  local name=${info[0]}
+  local version=${info[1]}
+
+  for releaseType in stable beta alpha; do
+    # removing current soft-link
+    local targetReleaseLocation="$installRoot/$name/$releaseType"
+    if [[ $* == *--update-$releaseType* || $* == *--update-all* ]]; then
+      if [[ -L "$targetReleaseLocation" ]]; then
+        rm $targetReleaseLocation
+      fi
+    fi
+
+    # creating soft-link
+    if ! [[ -L "$targetReleaseLocation" ]]; then
+      echo "- Updating $releaseType release to point to $version ($targetReleaseLocation -> $(dirname $targetReleaseLocation)/$version)"
+      ln -s $version $targetReleaseLocation
+    fi
+  done
+
+  unset info
+}
+
+# making sure jq is installed
+if ! [ -x "$(command -v jq)" ]; then
+  echo 'ERROR "jq" IS NOT INSTALLED (https://stedolan.github.io/jq/download/).' >&2
+  exit
+fi
+
+# production release
+if [[ $* == *--production* ]]; then
+  # removing any previous build folder
+  if [ -d "build_release" ]; then
+    rm -r "build_release"
+  fi
+
+  # making sure UPIPE_ROOT is defined
+  if [ -z $UPIPE_ROOT ]; then
+    echo "UPIPE_ROOT is not defined"
+    exit 1
+  fi
+
+  # showing a prompt confirmation, in case of a mistake
+  read -r -p "Are you sure you want to run the production release? [y/N] " response
+  if [[ "$response" =~ ^(yes|y)$ ]]; then
+
+    # running installation
+    qbs build_release project.coreConfig:$UPIPE_CORE_CONFIG project.releaseType:production qbs.installRoot:$UPIPE_ROOT
+
+    # updating release
+    updateReleaseSymlinks $UPIPE_ROOT/$UPIPE_CORE_CONFIG $@
+  fi
+
+# development release
+else
+  # making sure UPIPE_DEV_ROOT is defined
+  if [ -z $UPIPE_DEV_ROOT ]; then
+    echo "UPIPE_DEV_ROOT is not defined"
+    exit 1
+  fi
+
+  # TODO: workaround to avoid the installation not detecting
+  # modifications in files and installing a wrong version from the cache
+  # (rather than invalidating the cache).
+  # This issue has been noticed in qbs 1.8.1
+  if [ -d "default" ]; then
+    rm -r "default"
+  fi
+
+  # running installation
+  qbs project.coreConfig:$UPIPE_CORE_CONFIG project.releaseType:dev qbs.installRoot:$UPIPE_DEV_ROOT
+
+  # updating release
+  updateReleaseSymlinks $UPIPE_DEV_ROOT/$UPIPE_CORE_CONFIG $@
+fi

--- a/install.qbs
+++ b/install.qbs
@@ -1,0 +1,63 @@
+import qbs
+import qbs.File
+import qbs.FileInfo
+import qbs.TextFile
+
+Project {
+  id: main
+  property string coreConfig
+  property string releaseType
+
+  Probe {
+    id: info
+    property string fileName: "info.json"
+    property var data
+    configure: {
+      // making sure the info file exists
+      if (!File.exists(fileName)){
+        throw new Error("Cannot find: " + fileName)
+      }
+
+      // parsing info contents
+      data = JSON.parse(new TextFile(fileName).readAll())
+    }
+  }
+
+  Application {
+    Group {
+      qbs.installPrefix: {
+
+        // building the target location
+        targetPrefix = FileInfo.joinPaths(main.coreConfig, info.data.name, info.data.version)
+
+        // making sure to never override a production release
+        targetFullPath = FileInfo.joinPaths(qbs.installRoot, targetPrefix)
+        if (main.releaseType == "production" && File.exists(targetFullPath)) {
+          throw new Error("Cannot override an existent production release: " + targetFullPath)
+        }
+        console.info("Target: " + targetFullPath)
+
+        return targetPrefix
+      }
+
+      Group {
+          name: "Info File"
+          files: [
+            "info.json"
+          ]
+          qbs.install: true
+          qbs.installSourceBase: "./"
+      }
+
+      Group {
+          name: "Active Config"
+          files: [
+            "src/**"
+          ]
+          qbs.install: true
+          qbs.installDir: "config"
+          qbs.installSourceBase: "./src"
+      }
+    }
+  }
+}

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,0 +1,11 @@
+[pylama]
+format = pycodestyle
+skip = */__init__.py
+linters = pycodestyle,mccabe,pydocstyle,pyflakes
+ignore = E501,E302,E701,D100,D212,D200,D203,D413
+
+[pylama:pycodestyle]
+max_line_length = 120
+
+[pylama:pylint]
+max_line_length = 120

--- a/src/events/desktop-begin/onEveryTime/wk/linux/centos7/disableWacomTouchPad
+++ b/src/events/desktop-begin/onEveryTime/wk/linux/centos7/disableWacomTouchPad
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# making sure xsetwacom is available
+if wacomCommand="$(type -p xsetwacom)"; then
+
+  # querying the touch id
+  touchId=`xsetwacom list | grep TOUCH | grep -oE 'id: [0-9]*' | grep -oE '[0-9]*'`
+
+  # disabling touch
+  if ! [ -z "$touchId" ]; then
+    xsetwacom set $touchId touch off
+  fi
+fi

--- a/src/events/desktop-begin/onEveryTime/wk/linux/centos7/setPowerSaver
+++ b/src/events/desktop-begin/onEveryTime/wk/linux/centos7/setPowerSaver
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# standby happens after 60 minutes and screen turns off after 2 hours:
+# the first numerical argument is for standby, the second is for suspend,
+# and third is the off setting (the current configuration can be queried
+# via "xset -q")
+xset dpms 3600 0 7200

--- a/src/events/desktop-begin/onEveryTime/wk/linux/centos7/startSlack
+++ b/src/events/desktop-begin/onEveryTime/wk/linux/centos7/startSlack
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# initializes slack interface during startup
+slack&

--- a/src/events/desktop-begin/onFirstTime/wk/linux/centos7/createInstallationEnvInfo
+++ b/src/events/desktop-begin/onFirstTime/wk/linux/centos7/createInstallationEnvInfo
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import os
+import json
+
+def writeCurrentEnv(installationEnv):
+    """
+    Writes a json file with the current environment
+    """
+    with open(installationEnv, 'w') as f:
+        jsonData = json.dumps(dict(os.environ), sort_keys=True, indent=4, separators=(',', ': '))
+        f.write(jsonData)
+
+if __name__ == "__main__":
+    installationEnv = os.path.join(os.environ['USYS_LOCAL_DATA'], 'installationEnv.json');
+    writeCurrentEnv(installationEnv)

--- a/src/events/desktop-begin/onFirstTime/wk/linux/centos7/data/mimeapps.list
+++ b/src/events/desktop-begin/onFirstTime/wk/linux/centos7/data/mimeapps.list
@@ -1,0 +1,7 @@
+[Default Applications]
+video/quicktime=rv.desktop;
+image/x-exr=rv.desktop;
+
+[Added Associations]
+video/quicktime=rv.desktop;
+image/x-exr=rv.desktop;

--- a/src/events/desktop-begin/onFirstTime/wk/linux/centos7/setDefaultFileAssociation
+++ b/src/events/desktop-begin/onFirstTime/wk/linux/centos7/setDefaultFileAssociation
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# getting current script folder
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# mime apps configuration
+mimeappsFilePath="$dir/data/mimeapps.list"
+
+# old standard for user overrides, several applications still read/write to
+# it (kde 4 in centos 7)
+deprecatedConfigFolder=$HOME/.local/share/applications
+if ! [ -d "$deprecatedConfigFolder" ]; then
+    mkdir -p $deprecatedConfigFolder
+fi
+cp $mimeappsFilePath $deprecatedConfigFolder/
+
+# xdg standard (official way for user overrides)
+configFolder=$HOME/.config
+if ! [ -d "$configFolder" ]; then
+    mkdir -p $configFolder
+fi
+
+cp $mimeappsFilePath $configFolder/

--- a/src/events/system-begin/all/linux/centos7/epel
+++ b/src/events/system-begin/all/linux/centos7/epel
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# adding epel repository
+if ! [ -f "/etc/yum.repos.d/epel.repo" ]; then
+  yum install -y epel-release
+fi

--- a/src/events/system-begin/all/linux/centos7/main
+++ b/src/events/system-begin/all/linux/centos7/main
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script file ("main") gets executed first before any other script under
+# the same directory.
+
+# cleaning yum cache
+yum clean all

--- a/src/events/system-begin/all/linux/centos7/maya
+++ b/src/events/system-begin/all/linux/centos7/maya
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# required dependencies to run maya on centos7
+yum install -y compat-libtiff3
+yum install -y xorg-x11-fonts-ISO8859-1-100dpi xorg-x11-fonts-ISO8859-1-75dpi xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi
+yum install -y mesa-libGLw csh libXp libXp-devel gamin audiofile audiofile-devel e2fsprogs-libs tcsh libXpm

--- a/src/events/system-begin/all/linux/centos7/ntp
+++ b/src/events/system-begin/all/linux/centos7/ntp
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# syncing time (UMEDIA_NTP_SERVER is defined by ufacility)
+if ! [ -z "$UMEDIA_NTP_SERVER" ]; then
+  ntpdate -s $UMEDIA_NTP_SERVER
+fi

--- a/src/events/system-begin/all/linux/centos7/nuxDesktop
+++ b/src/events/system-begin/all/linux/centos7/nuxDesktop
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if ! [ -f "/etc/yum.repos.d/nux-dextop.repo" ]; then
+  # adding epel repository
+  yum install -y epel-release
+
+  # adding nux-desktop repository
+  yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+fi
+
+# ipa/freeipa seems broken on centos 7.3:
+# https://www.centos.org/forums/viewtopic.php?t=63500
+# - Quote: "The ipa/freeipa conflicts are a known bug upstream and will be fixed in 7.4 when that arrives.
+# It causes no problems and you can ignore the messages."
+yum install -y vlc --skip-broken
+yum install -y smplayer ffmpeg
+
+# installing video codecs (https://wiki.centos.org/TipsAndTricks/MultimediaOnCentOS7) used by firefox, nuke...
+yum install -y libdvdcss gstreamer{,1}-plugins-ugly gstreamer-plugins-bad-nonfree gstreamer1-plugins-bad-freeworld

--- a/src/events/system-begin/wk/linux/centos7/atom
+++ b/src/events/system-begin/wk/linux/centos7/atom
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# required to run atom on centos
+yum install -y xscreensaver --enablerepo=extras

--- a/src/events/system-begin/wk/linux/centos7/kde
+++ b/src/events/system-begin/wk/linux/centos7/kde
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y kde-workspace kmix ksysguard ksnapshot

--- a/src/events/system-begin/wk/linux/centos7/kdiff3
+++ b/src/events/system-begin/wk/linux/centos7/kdiff3
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# dev application used to diff files
+yum install -y kdiff3

--- a/src/events/system-begin/wk/linux/centos7/shellcheck
+++ b/src/events/system-begin/wk/linux/centos7/shellcheck
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# development dependency used to lint bash syntax
+yum install -y ShellCheck


### PR DESCRIPTION
This pull request adds examples of configurations used by uevents. Illustrating how uevents locates the configurations. 

In the initial pull request we can find examples about:
**desktop-begin _[onFirstTime, onEveryTime]_**: triggered during KDE/gnome sessions
**system-begin**: triggered during booting time


> These configurations were previously localized under uevents

# Change Log
- Added examples about desktop-begin and system-begin